### PR TITLE
Fix SMTP2GO analytics fetch

### DIFF
--- a/app.py
+++ b/app.py
@@ -1450,7 +1450,8 @@ def fetch_smtp2go_analytics():
             'days': 30
         }
         
-        response = requests.get(stats_url, params=params)
+        response = requests.post(stats_url, json=params)
+        response.raise_for_status()
         data = response.json()
         
         if data.get('data'):


### PR DESCRIPTION
## Summary
- correct HTTP method when fetching stats from SMTP2GO
- ensure HTTP errors are raised

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684d29a068a48323a04ab06507a86a5c