### PR TITLE
Fix analytics parsing for SMTP2GO

### DIFF
--- a/app.py
+++ b/app.py
@@ -1478,7 +1478,9 @@ def fetch_smtp2go_analytics():
             if isinstance(result, list):
                 return {'stats': result}
             elif isinstance(result, dict):
-                return result if 'stats' in result else {'stats': result}
+                # Some responses may only contain totals without a 'stats' key
+                # Normalize so that 'stats' is always a list of dictionaries
+                return result if 'stats' in result else {'stats': [result]}
             else:
                 st.error("Unexpected analytics format")
                 return None


### PR DESCRIPTION
## Summary
- normalize analytics data so `stats` is always a list

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684d2f0a67d48323ba612b8dc703180d