### PR TITLE
Fix spam score comparison

### DIFF
--- a/app.py
+++ b/app.py
@@ -903,7 +903,12 @@ def check_postmark_spam(template_html, subject="Test"):
         )
         if response.status_code == 200:
             data = response.json()
-            return data.get("score"), data.get("report")
+            score = data.get("score")
+            try:
+                score = float(score)
+            except (TypeError, ValueError):
+                score = None
+            return score, data.get("report")
         else:
             st.error(f"Spamcheck failed with status code {response.status_code}")
             return None, None


### PR DESCRIPTION
## Summary
- convert Postmark API score to a float before using it

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68523800ed748323834f50e7ab27e2d4