### PR TITLE
Fix journal refresh without invalid rerun

### DIFF
--- a/app.py
+++ b/app.py
@@ -1064,7 +1064,7 @@ def load_campaign_history():
 
 
 # Helper to refresh template and subjects when journal changes
-def refresh_journal_data(rerun: bool = False):
+def refresh_journal_data():
     """Reload template and subjects for the currently selected journal."""
     journal = st.session_state.get("selected_journal")
     if not journal:
@@ -1077,9 +1077,6 @@ def refresh_journal_data(rerun: bool = False):
     subjects = load_subjects_from_firebase(journal)
     if subjects is not None:
         st.session_state.journal_subjects[journal] = subjects
-
-    if rerun:
-        st.experimental_rerun()
 
 # Email Campaign Section
 def email_campaign_section():
@@ -1105,7 +1102,7 @@ def email_campaign_section():
             JOURNALS,
             index=JOURNALS.index(st.session_state.selected_journal)
             if st.session_state.selected_journal in JOURNALS else 0,
-            on_change=lambda: refresh_journal_data(True),
+            on_change=refresh_journal_data,
             key="selected_journal",
         )
         refresh_journal_data()


### PR DESCRIPTION
## Summary
- avoid `st.experimental_rerun()` inside journal refresh helper
- trigger refresh on journal change directly

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68528f7b2e20832397a51488bd9856e2