### PR TITLE
Remove redundant info message

### DIFF
--- a/app.py
+++ b/app.py
@@ -1312,10 +1312,7 @@ def email_campaign_section():
 
             st.markdown(preview_html, unsafe_allow_html=True)
     else:
-        st.info("Click 'Load Subjects & Template from Cloud' to manage subjects and templates.")
-
-
-
+        # Informational message removed per user request to keep the interface concise.
     # File Upload
     st.subheader("Recipient List")
     file_source = st.radio("Select file source", ["Local Upload", "Cloud Storage"])


### PR DESCRIPTION
## Summary
- avoid clutter by dropping the info note about managing subjects and templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a29b140c83238b57c0ddd8d12d0c