### PR TITLE
Add Google Analytics data display

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ firebase-admin==6.2.0
 matplotlib==3.8.2
 streamlit-ace==0.1.1
 firebase-functions
+google-analytics-data==0.13.1


### PR DESCRIPTION
## Summary
- integrate Google Analytics using `google-analytics-data`
- fetch page view metrics with service account credentials
- display website traffic on Analytics page
- update requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a30887f94832382d14cf9afe0765d