### PR TITLE
Add GA tracking snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
+This application is a Streamlit-based email management suite.
 
+### Google Analytics
+
+To display website traffic metrics on the **Analytics** page, set the following
+environment variables:
+
+```
+GA_PROPERTY_ID=<numeric property id>
+GA_CREDENTIALS_JSON=<service account JSON string>
+GA_MEASUREMENT_ID=<measurement id>
+```
+
+The measurement ID enables page view tracking via the gtag script. The property
+ID and credentials are required to fetch aggregated statistics.

--- a/app.py
+++ b/app.py
@@ -128,6 +128,23 @@ def set_light_theme():
 
 set_light_theme()
 
+# Google Analytics tracking
+def inject_ga_tracking(measurement_id: str):
+    """Embed Google Analytics script for page view tracking."""
+    if not measurement_id:
+        return
+    ga_snippet = f"""
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={measurement_id}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){{dataLayer.push(arguments);}}
+      gtag('js', new Date());
+      gtag('config', '{measurement_id}');
+    </script>
+    """
+    st.markdown(ga_snippet, unsafe_allow_html=True)
+
 # Authentication System
 def check_auth():
     if 'authenticated' not in st.session_state:
@@ -353,7 +370,8 @@ def load_config():
         },
         'google_analytics': {
             'property_id': os.getenv("GA_PROPERTY_ID", ""),
-            'credentials_json': os.getenv("GA_CREDENTIALS_JSON", "")
+            'credentials_json': os.getenv("GA_CREDENTIALS_JSON", ""),
+            'measurement_id': os.getenv("GA_MEASUREMENT_ID", "")
         },
         'webhook': {
             'url': os.getenv("WEBHOOK_URL", "")
@@ -2858,6 +2876,9 @@ def show_email_analytics():
 def main():
     # Check authentication
     check_auth()
+
+    # Inject Google Analytics tracking snippet if configured
+    inject_ga_tracking(config['google_analytics'].get('measurement_id'))
     
     # Main app for authenticated users
     st.title(f"PPH Email Manager - Welcome admin")


### PR DESCRIPTION
## Summary
- provide config field for GA measurement id
- inject GA tracking snippet
- document how to configure GA variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a33cf3a2883239f5983e20d7980f3