### PR TITLE
Fix SMTP2GO analytics data retrieval

### DIFF
--- a/app.py
+++ b/app.py
@@ -2651,7 +2651,8 @@ def fetch_smtp2go_analytics():
         payload = {
             "api_key": api_key,
             "date_start": (datetime.utcnow() - timedelta(days=30)).strftime("%Y-%m-%d"),
-            "date_end": datetime.utcnow().strftime("%Y-%m-%d")
+            "date_end": datetime.utcnow().strftime("%Y-%m-%d"),
+            "group_by": "day"
         }
 
         # Email history


### PR DESCRIPTION
## Summary
- ensure SMTP2GO stats API groups data by day

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685a60b8a07c8323a1789d428aa989b7