### PR TITLE
Fix hidden sidebar toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,15 +106,6 @@ def set_light_theme():
     .risky-email-btn button:active {
         transform: scale(0.97);
     }
-    /* Replace sidebar toggle arrow with a simple > icon */
-    div[data-testid="collapsedControl"] svg {
-        display: none;
-    }
-    div[data-testid="collapsedControl"]::after {
-        content: ">";
-        font-size: 20px;
-        color: var(--primary-color);
-    }
     /* Sidebar appearance */
     section[data-testid="stSidebar"] {
         background-color: #e6f0ff;


### PR DESCRIPTION
## Summary
- remove custom CSS that hid the sidebar toggle arrow

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6867b886282c8323a502ece60d50f088