### PR TITLE
Add blinking notice on login page

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,9 +150,25 @@ set_light_theme()
 def check_auth():
     if 'authenticated' not in st.session_state:
         st.session_state.authenticated = False
-    
+
     if not st.session_state.authenticated:
         st.title("PPH Email Manager - Login")
+        st.markdown(
+            """
+            <style>
+            .blink {
+                animation: blinker 1s linear infinite;
+                color: red;
+                font-weight: bold;
+            }
+            @keyframes blinker {
+                50% { opacity: 0; }
+            }
+            </style>
+            <p class="blink">Attention required!!! Contact app adminiatrator for help.</p>
+            """,
+            unsafe_allow_html=True,
+        )
         with st.form("login_form"):
             username = st.text_input("Username")
             password = st.text_input("Password", type="password")


### PR DESCRIPTION
## Summary
- Show blinking red notice on login screen with admin contact message

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c4d89248f0832398d2e6c3a1cdac5f