### PR TITLE
Remove blinking login notice

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,22 +153,6 @@ def check_auth():
 
     if not st.session_state.authenticated:
         st.title("PPH Email Manager - Login")
-        st.markdown(
-            """
-            <style>
-            .blink {
-                animation: blinker 1s linear infinite;
-                color: red;
-                font-weight: bold;
-            }
-            @keyframes blinker {
-                50% { opacity: 0; }
-            }
-            </style>
-            <p class="blink">Attention required!!! Contact app adminiatrator for help.</p>
-            """,
-            unsafe_allow_html=True,
-        )
         with st.form("login_form"):
             username = st.text_input("Username")
             password = st.text_input("Password", type="password")


### PR DESCRIPTION
## Summary
- remove the blinking attention notice from the login page so the warning no longer appears

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8c19a088083239a3d26860f8e934d