### PR TITLE
Add Mailgun unsubscribe webhook and Streamlit management tab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ firebase-admin==6.2.0
 matplotlib==3.8.2
 streamlit-ace==0.1.1
 firebase-functions
+Flask==2.3.3


### PR DESCRIPTION
## Summary
- add a Flask-based /unsubscribe webhook that validates Mailgun signatures and records opt-outs in Firestore
- cache unsubscribed contacts so campaigns skip them automatically and start the webhook listener with the Streamlit app
- surface an Unsubscribed Users tab in the campaign workflow with refresh/download tools and add the Flask dependency

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e4b593379c8323a4a63d5bbd720e17