### PR TITLE
Add Streamlit unsubscribe page and enable template link actions

### DIFF
--- a/pages/unsubscribe.py
+++ b/pages/unsubscribe.py
@@ -1,0 +1,181 @@
+"""Streamlit page for managing unsubscribe requests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Optional
+from urllib.parse import urlencode
+
+import sys
+
+import streamlit as st
+from streamlit.errors import StreamlitAPIException
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from app import (
+    EMAIL_VALIDATION_REGEX,
+    initialize_firebase,
+    is_email_unsubscribed,
+    load_unsubscribed_users,
+    set_email_resubscribed,
+    set_email_unsubscribed,
+)
+
+PAGE_TITLE = "Manage Email Preferences"
+
+
+@st.cache_resource(show_spinner=False)
+def _load_unsubscribe_template():
+    templates_dir = Path(__file__).resolve().parents[1] / "templates"
+    env = Environment(
+        loader=FileSystemLoader(str(templates_dir)),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+    return env.get_template("unsubscribe.html")
+
+
+def _get_query_params() -> Dict[str, str]:
+    try:
+        params = dict(st.query_params)
+    except AttributeError:
+        params = {
+            key: (value[0] if isinstance(value, list) else value)
+            for key, value in st.experimental_get_query_params().items()
+        }
+    return {key: value for key, value in params.items() if value is not None}
+
+
+def _set_query_params(params: Dict[str, str]):
+    params = {key: value for key, value in params.items() if value}
+    try:
+        st.query_params.clear()
+        for key, value in params.items():
+            st.query_params[key] = value
+    except AttributeError:
+        st.experimental_set_query_params(**params)
+
+
+def _pop_feedback(email: str) -> Optional[Dict[str, str]]:
+    feedback = st.session_state.get("unsubscribe_feedback")
+    if feedback and feedback.get("email") == email:
+        st.session_state.pop("unsubscribe_feedback", None)
+        return feedback
+    return None
+
+
+def _store_feedback(email: str, message: str, status: str):
+    st.session_state.unsubscribe_feedback = {
+        "email": email,
+        "message": message,
+        "status": status,
+    }
+
+
+def _render_template(**context):
+    template = _load_unsubscribe_template()
+    html = template.render(**context)
+    st.components.v1.html(html, height=800, scrolling=True)
+
+
+def _ensure_firebase_loaded():
+    if not st.session_state.firebase_initialized:
+        initialize_firebase()
+    if not st.session_state.unsubscribed_users_loaded:
+        load_unsubscribed_users()
+
+
+def _process_action(action: str, email: str) -> Optional[Dict[str, str]]:
+    if action not in {"unsubscribe", "resubscribe"}:
+        return None
+
+    if action == "unsubscribe":
+        success = set_email_unsubscribed(email)
+        if success:
+            load_unsubscribed_users(force_refresh=True)
+            return {
+                "message": "You have been unsubscribed successfully and will be excluded from future campaigns.",
+                "status": "success",
+            }
+    else:
+        success = set_email_resubscribed(email)
+        if success:
+            load_unsubscribed_users(force_refresh=True)
+            return {
+                "message": "You have been re-subscribed successfully and will receive future campaigns.",
+                "status": "success",
+            }
+
+    return {
+        "message": "We were unable to process your request at this time. Please try again later.",
+        "status": "error",
+    }
+
+
+def main():
+    try:
+        st.set_page_config(page_title=PAGE_TITLE, layout="centered", initial_sidebar_state="collapsed")
+    except StreamlitAPIException:
+        # The host app (app.py) sets page config already when running in multipage mode.
+        pass
+
+    params = _get_query_params()
+    email = (params.get("email") or "").strip()
+    action = (params.get("action") or "").strip().lower()
+
+    message = None
+    status = "info"
+    show_actions = False
+    unsubscribed = False
+    excluded_from_future_sends = False
+
+    if not email:
+        message = "No email address was provided for unsubscribe."
+        status = "error"
+    elif not EMAIL_VALIDATION_REGEX.match(email):
+        message = "The email address provided appears to be invalid."
+        status = "error"
+    else:
+        _ensure_firebase_loaded()
+        unsubscribed = is_email_unsubscribed(email)
+        excluded_from_future_sends = unsubscribed
+        show_actions = True
+
+        if action:
+            feedback = _process_action(action, email)
+            if feedback:
+                _store_feedback(email, feedback["message"], feedback["status"])
+            _set_query_params({"email": email})
+            st.experimental_rerun()
+
+        feedback = _pop_feedback(email)
+        if feedback:
+            message = feedback["message"]
+            status = feedback["status"]
+        elif unsubscribed:
+            message = "This email address is currently unsubscribed."
+            status = "info"
+
+    context = {
+        "email": email,
+        "message": message,
+        "status": status,
+        "unsubscribed": unsubscribed,
+        "show_actions": show_actions,
+        "excluded_from_future_sends": excluded_from_future_sends,
+        "current_year": datetime.now(timezone.utc).year,
+        "use_links_for_actions": show_actions,
+        "link_target": "_top",
+        "unsubscribe_action_url": f"?{urlencode({'email': email, 'action': 'unsubscribe'})}" if show_actions else "",
+        "resubscribe_action_url": f"?{urlencode({'email': email, 'action': 'resubscribe'})}" if show_actions else "",
+    }
+
+    _render_template(**context)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/unsubscribe.html
+++ b/templates/unsubscribe.html
@@ -113,11 +113,13 @@
         margin-bottom: 28px;
       }
 
-      .action-form {
+      .action-form,
+      .action-link-wrapper {
         flex: 1 1 200px;
       }
 
-      button {
+      button,
+      .action-link {
         width: 100%;
         border: none;
         border-radius: 999px;
@@ -126,11 +128,24 @@
         font-weight: 600;
         cursor: pointer;
         transition: transform 0.18s ease, box-shadow 0.18s ease;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        text-decoration: none;
+        box-shadow: 0 12px 25px rgba(31, 102, 255, 0.18);
       }
 
-      button:hover {
+      button:hover,
+      .action-link:hover {
         transform: translateY(-1px);
-        box-shadow: 0 12px 25px rgba(31, 102, 255, 0.18);
+        box-shadow: 0 16px 30px rgba(31, 102, 255, 0.25);
+      }
+
+      button:focus,
+      .action-link:focus {
+        outline: none;
+        box-shadow: 0 0 0 4px rgba(31, 102, 255, 0.25);
       }
 
       .btn-unsubscribe {
@@ -148,6 +163,7 @@
         cursor: not-allowed;
         box-shadow: none;
         transform: none !important;
+        pointer-events: none;
       }
 
       .details {
@@ -201,7 +217,29 @@
 
         {% if show_actions %}
         <div class="actions">
-          <form method="post" class="action-form">
+          {% if use_links_for_actions %}
+          <div class="action-link-wrapper">
+            <a
+              href="{{ unsubscribe_action_url }}"
+              class="action-link btn-unsubscribe{% if unsubscribed %} btn-disabled{% endif %}"
+              target="{{ link_target|default('_self') }}"
+              {% if unsubscribed %}aria-current="true"{% endif %}
+            >
+              Unsubscribe Me
+            </a>
+          </div>
+          <div class="action-link-wrapper">
+            <a
+              href="{{ resubscribe_action_url }}"
+              class="action-link btn-resubscribe{% if not unsubscribed %} btn-disabled{% endif %}"
+              target="{{ link_target|default('_self') }}"
+              {% if not unsubscribed %}aria-current="true"{% endif %}
+            >
+              Re-subscribe Me
+            </a>
+          </div>
+          {% else %}
+          <form method="{{ form_method|default('post') }}" class="action-form">
             <input type="hidden" name="email" value="{{ email }}" />
             <input type="hidden" name="action" value="unsubscribe" />
             <button
@@ -212,7 +250,7 @@
               Unsubscribe Me
             </button>
           </form>
-          <form method="post" class="action-form">
+          <form method="{{ form_method|default('post') }}" class="action-form">
             <input type="hidden" name="email" value="{{ email }}" />
             <input type="hidden" name="action" value="resubscribe" />
             <button
@@ -223,6 +261,7 @@
               Re-subscribe Me
             </button>
           </form>
+          {% endif %}
         </div>
         {% endif %}
 


### PR DESCRIPTION
## Summary
- add a dedicated Streamlit page that serves the unsubscribe experience using the existing template and Firestore helpers
- extend the unsubscribe template to support both traditional form submissions and link-based actions so it can render inside Streamlit

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e4ea3e609883238ee4083675221c80