### PR TITLE
Redirect unsubscribe requests to HTML page

### DIFF
--- a/templates/unsubscribe.html
+++ b/templates/unsubscribe.html
@@ -239,7 +239,11 @@
             </a>
           </div>
           {% else %}
-          <form method="{{ form_method|default('post') }}" class="action-form">
+          <form
+            method="{{ form_method|default('post') }}"
+            action="{{ form_action_url|default('') }}"
+            class="action-form"
+          >
             <input type="hidden" name="email" value="{{ email }}" />
             <input type="hidden" name="action" value="unsubscribe" />
             <button
@@ -250,7 +254,11 @@
               Unsubscribe Me
             </button>
           </form>
-          <form method="{{ form_method|default('post') }}" class="action-form">
+          <form
+            method="{{ form_method|default('post') }}"
+            action="{{ form_action_url|default('') }}"
+            class="action-form"
+          >
             <input type="hidden" name="email" value="{{ email }}" />
             <input type="hidden" name="action" value="resubscribe" />
             <button


### PR DESCRIPTION
## Summary
- redirect unsubscribe webhook responses to a dedicated unsubscribe.html renderer
- add a Flask endpoint that serves the unsubscribe template with proper context
- update the unsubscribe template forms to submit to the webhook route after the redirect

## Testing
- python -m compileall app.py templates/unsubscribe.html

------
https://chatgpt.com/codex/tasks/task_e_68e4efbf5cd08323b3e5879ec0f58ebc