### PR TITLE
Ensure unsubscribe page initializes session state defaults

### DIFF
--- a/pages/unsubscribe.py
+++ b/pages/unsubscribe.py
@@ -76,6 +76,13 @@ def _store_feedback(email: str, message: str, status: str):
     }
 
 
+def _ensure_session_state_defaults():
+    if "firebase_initialized" not in st.session_state:
+        st.session_state.firebase_initialized = False
+    if "unsubscribed_users_loaded" not in st.session_state:
+        st.session_state.unsubscribed_users_loaded = False
+
+
 def _render_template(**context):
     template = _load_unsubscribe_template()
     html = template.render(**context)
@@ -83,6 +90,7 @@ def _render_template(**context):
 
 
 def _ensure_firebase_loaded():
+    _ensure_session_state_defaults()
     if not st.session_state.firebase_initialized:
         initialize_firebase()
     if not st.session_state.unsubscribed_users_loaded:


### PR DESCRIPTION
## Summary
- add a helper to initialize required Streamlit session state keys on the unsubscribe page
- ensure Firebase initialization and unsubscribe cache loading use the defaults helper before access

## Testing
- python -m compileall pages/unsubscribe.py

------
https://chatgpt.com/codex/tasks/task_e_68e4f38675f483239156d05e116cd49e