### PR TITLE
Start webhook server on app startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -1154,6 +1154,11 @@ def initialize_firebase():
         st.error(f"Firebase initialization failed: {str(e)}")
         return False
 
+# Ensure Firebase and the webhook server are ready before rendering any UI
+if not st.session_state.get("firebase_initialized"):
+    initialize_firebase()
+ensure_webhook_server()
+
 def get_firestore_db():
     if not initialize_firebase():
         st.error("Firebase initialization failed")


### PR DESCRIPTION
## Summary
- initialize Firebase during module import if it has not been initialized
- start the webhook server as soon as the app module loads so /api/unsubscribe is available immediately

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e618a4b0608323a78cf42946c5af4d