### PR TITLE
Start webhook server alongside Streamlit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ matplotlib==3.8.2
 streamlit-ace==0.1.1
 firebase-functions
 Flask==2.3.3
+Flask-Cors==4.0.0
+waitress==3.0.0


### PR DESCRIPTION
## Summary
- start the Flask webhook app in a background thread with waitress before the Streamlit UI loads
- enable CORS for the webhook app and add the necessary dependencies

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e61c6aa2008323b0c9e2c2de27343b