### PR TITLE
Restrict webhook CORS origins

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,15 +36,25 @@ from urllib.parse import urlencode, urlsplit
 
 
 webhook_app = Flask(__name__)
+from flask_cors import CORS
+CORS(
+    webhook_app,
+    resources={
+        r"/*": {
+            "origins": [
+                "https://pphmjopenaccess.com",
+                "https://www.pphmjopenaccess.com",
+            ]
+        }
+    },
+    supports_credentials=True,
+)
 
 # ---------------------------
 # Start Flask webhook server
 # ---------------------------
 from threading import Thread
-from flask_cors import CORS
 from waitress import serve
-
-CORS(webhook_app, resources={r"/*": {"origins": "*"}})
 
 def start_webhook():
     try:


### PR DESCRIPTION
## Summary
- limit the Flask webhook CORS configuration to the pphmjopenaccess.com domains
- enable credential support for cross-origin requests from the unsubscribe page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e630fd4b488323807b421ea71f042f